### PR TITLE
Add bulma (just some components) with examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-loader": "7.0.0",
     "babel-preset-react-app": "^3.0.1",
     "babel-runtime": "6.23.0",
+    "bulma": "^0.5.0",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
     "css-loader": "0.28.4",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import Helmet from 'react-helmet';
+import ExampleModal from 'components/ExampleModal';
 import reactLogo from 'assets/images/react-logo.png';
 import sassLogo from 'assets/images/sass-logo.svg';
 import cssModulesLogo from 'assets/images/css-modules-logo.png';
@@ -33,6 +34,17 @@ class App extends PureComponent {
             To get started, edit <code>src/App.js</code> and save to reload.
           </p>
         </div>
+        <section className={styles.componentsSection}>
+          <h2 className={styles.componentsSectionTitle}>
+            Here are some example components!
+          </h2>
+          <div>
+            <div>
+              <h3 className={styles.componentTitle}>Example Modal</h3>
+              <ExampleModal />
+            </div>
+          </div>
+        </section>
       </div>
     );
   }

--- a/src/App.scssm
+++ b/src/App.scssm
@@ -27,7 +27,7 @@
 
 .title {
   font-size: 28px;
-  font-weight: 500px;
+  font-weight: 400;
   margin: 0;
 }
 
@@ -39,4 +39,20 @@
   p {
     margin: 0;
   }
+}
+
+.componentsSection {
+  padding: 20px;
+}
+
+.componentsSectionTitle {
+  color: $black;
+  font-size: 24px;
+  font-weight: 500;
+}
+
+.componentTitle {
+  color: $black;
+  font-size: 20px;
+  font-weight: 400;
 }

--- a/src/components/ExampleModal/index.jsx
+++ b/src/components/ExampleModal/index.jsx
@@ -1,0 +1,44 @@
+import React, { PureComponent } from 'react';
+import Modal from 'components/Modal';
+import styles from './styles.scssm';
+
+class ExampleModal extends PureComponent {
+  state = {
+    active: false,
+  };
+
+  render() {
+    const {
+      active,
+    } = this.state;
+
+    return (
+      <div>
+        <button
+          className={styles.button}
+          onClick={() => {
+            this.setState({
+              active: true,
+            });
+          }}
+        >
+          Open the example modal!
+        </button>
+        <Modal
+          active={active}
+          handleClose={() => {
+            this.setState({
+              active: false,
+            });
+          }}
+        >
+          <div className={styles.modalContent}>
+            This is an example modal! Hope you find it useful!
+          </div>
+        </Modal>
+      </div>
+    );
+  }
+}
+
+export default ExampleModal;

--- a/src/components/ExampleModal/styles.scssm
+++ b/src/components/ExampleModal/styles.scssm
@@ -1,0 +1,17 @@
+@import "~styles/commons/index";
+
+.button {
+  border: 0;
+  border-radius: 5px;
+  background-color: palevioletred;
+  color: $white;
+  font-size: 20px;
+  font-weight: 400;
+  padding: 10px 20px;
+}
+
+.modalContent {
+  border-radius: 5px;
+  background-color: $white;
+  padding: 40px;
+}

--- a/src/components/Modal/index.jsx
+++ b/src/components/Modal/index.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const propTypes = {
+  active: PropTypes.bool.isRequired,
+  handleClose: PropTypes.func.isRequired,
+  children: PropTypes.node,
+};
+
+const defaultProps = {
+  children: 'Add content through children nodes',
+};
+
+const Modal = ({
+  active,
+  handleClose,
+  children,
+}) => (
+  <div className={`modal ${active ? 'is-active' : ''}`}>
+    <div className="modal-background" />
+    <div className="modal-content">
+      {children}
+    </div>
+    <button
+      className="modal-close is-large"
+      onClick={handleClose}
+    />
+  </div>
+);
+
+Modal.propTypes = propTypes;
+
+Modal.defaultProps = defaultProps;
+
+export default Modal;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,3 +1,7 @@
+// Vendors
+
+@import "vendors/bulma";
+
 // Commons
 
 @import "commons/index";

--- a/src/styles/vendors/bulma.scss
+++ b/src/styles/vendors/bulma.scss
@@ -1,0 +1,2 @@
+@import '~bulma/sass/utilities/_all';
+@import '~bulma/sass/components/modal';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,6 +1161,10 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+bulma@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.5.0.tgz#09a7932c1c15aa7ef92840f7a50b1bfebbfd5461"
+
 bytes@2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"


### PR DESCRIPTION
Adds bulma dependency but only imports the utilities and its modal
components. Adds and example components that uses an implementation of
the Bulma modal. Adds a component list section to the App.js that may be
useful to show some generic components implementations.